### PR TITLE
Updates for installation logic

### DIFF
--- a/devtools/build_system.py
+++ b/devtools/build_system.py
@@ -279,6 +279,8 @@ class BuildSystem:
                 f.write('\n    {}'.format(file_))
         f.write('\n    )\n\n')
 
+        f.write('add_library( njoy::{0} ALIAS {0} )\n\n'.format(self.name))
+
         f.write(
             'target_include_directories( {0} {1} ${{prefix}} )\n\n'
             ''.format(self.name, link_type)
@@ -350,6 +352,7 @@ class BuildSystem:
                 
                 install(EXPORT {0}-targets
                   FILE "{0}-targets.cmake"
+                  NAMESPACE njoy::
                   DESTINATION share/cmake/{0}
                 )
                 

--- a/devtools/build_system.py
+++ b/devtools/build_system.py
@@ -57,6 +57,15 @@ class BuildSystem:
             return os.path.basename(self._path)
 
     @property
+    def testName(self):
+        """ The name of the interface library used for testing dependencies, derived from the name
+
+        """
+
+        return self.name + "_testing"
+
+
+    @property
     def dependencies(self):
         """ List of dependencies.
 
@@ -128,16 +137,25 @@ class BuildSystem:
                 # Setup
                 #######################################################################
 
-                message( STATUS "Adding {} unit testing" )
-                enable_testing()
+                message( STATUS "Adding {0} unit testing" )
 
+                add_library( {1} INTERFACE )
+                target_link_libraries( {1} INTERFACE {0} )
 
+                """.format(self.name, self.testName))
+                )
+
+            # this expects catch-adapter to be used for the testing library and should be updated if this is replaced with another lib (e.g. Catch2)
+            if (any(dependency.name == "catch-adapter" for dependency in self.dependencies)):
+                f.write('target_link_libraries({0} INTERFACE catch-adapter)\n'.format(self.testName))
+
+            f.write(dedent("""
                 #######################################################################
                 # Unit testing directories
                 #######################################################################
 
-                """.format(self.name))
-                )
+                """))
+
 
             for dir_ in test_directories:
                 f.write('add_subdirectory( {} )\n'.format(dir_))
@@ -159,9 +177,15 @@ class BuildSystem:
             ########################################################################
             # Preamble
             ########################################################################
+
+            set(subproject OFF)
+            if(DEFINED PROJECT_NAME)
+              set(subproject ON)
+            endif()
             
             cmake_minimum_required( VERSION 3.14 )
             project( {0} LANGUAGES CXX )
+
             
             
             ########################################################################
@@ -171,8 +195,15 @@ class BuildSystem:
             set( CMAKE_CXX_STANDARD 17 )
             set( CMAKE_CXX_STANDARD_REQUIRED YES )
             
-            option( {0}_unit_tests
+            include(CTest)
+            include(CMakeDependentOption)
+
+            cmake_dependent_option( {0}_unit_tests
                 "Compile the {0} unit tests and integrate with ctest" ON
+                BUILD_TESTING AND NOT ${{subproject}}
+            )
+            option( {0}_installation
+                "Install {0}" ON
                 )
             option( strict_compile
                 "Treat all warnings as errors." ON
@@ -201,8 +232,6 @@ class BuildSystem:
                     "Options for where to fetch repositories: develop, release, local"
                     )
                 
-                message( STATUS "Using ${{REPOSITORIES}} repositories" )
-
                 if( REPOSITORIES STREQUAL "develop" )
                     include( cmake/develop_dependencies.cmake )
                 
@@ -223,6 +252,12 @@ class BuildSystem:
             ########################################################################
             # Project targets
             ########################################################################
+            include(GNUInstallDirs)
+
+            string( CONCAT prefix
+              "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>"
+              "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+            )
                 
             """)
             )
@@ -242,18 +277,32 @@ class BuildSystem:
         else:
             for file_ in self._tree.list_compiled_source():
                 f.write('\n    {}'.format(file_))
-        f.write('\n    )\n')
+        f.write('\n    )\n\n')
 
         f.write(
-            'target_include_directories( {0} {1} src/ )\n'
+            'target_include_directories( {0} {1} ${{prefix}} )\n\n'
             ''.format(self.name, link_type)
             )
 
-        if self.dependencies:
+        # see if the dependencies list needs to be written
+        need_to_write_link_libraries_list  = (self.dependencies and 
+                                  not any(dependency.name == "spdlog" for dependency in self.dependencies) and
+                                  not any(dependency.name == "catch-adapter" for dependency in self.dependencies))
+
+        if need_to_write_link_libraries_list:
             f.write('target_link_libraries( {}\n'.format(self.name))
             for d in self.dependencies:
-                f.write('    {0} {1}\n'.format(link_type, d.name))
-            f.write('    )\n')
+                if (d.name != "spdlog" and d.name != "catch-adapter"):
+                    f.write('    {0} {1}\n'.format(link_type, d.name))
+            f.write('    )\n\n')
+
+        if (any(dependency.name == "spdlog" for dependency in self.dependencies)):
+            f.write('# treat spdlog specially due to mixed namespace usage\n')
+            f.write('if (TARGET spdlog::spdlog)\n')
+            f.write('    target_link_libraries({0} {1} spdlog::spdlog)\n'.format(self.name, link_type))
+            f.write('else()\n')
+            f.write('    target_link_libraries({0} {1} spdlog)\n'.format(self.name, link_type))
+            f.write('endif()\n\n')
 
         if not self._tree.header_only:
             f.write(dedent("""\
@@ -277,11 +326,57 @@ class BuildSystem:
             if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
             
                 # unit testing
-                if( {}_unit_tests )
+                if( ${{{}_unit_tests}} )
                     include( cmake/unit_testing.cmake )
                 endif()
             
             endif()
+            """.format(self.name))
+            )
+
+        f.write(dedent("""\
+            #######################################################################
+            # Installation 
+            #######################################################################
+
+            if({0}_installation)
+                include(CMakePackageConfigHelpers)
+                
+                install(TARGETS {0} EXPORT {0}-targets
+                  ARCHIVE DESTINATION "${{CMAKE_INSTALL_LIBDIR}}"
+                  LIBRARY DESTINATION "${{CMAKE_INSTALL_LIBDIR}}"
+                  RUNTIME DESTINATION "${{CMAKE_INSTALL_BINDIR}}"
+                )
+                
+                install(EXPORT {0}-targets
+                  FILE "{0}-targets.cmake"
+                  DESTINATION share/cmake/{0}
+                )
+                
+                configure_package_config_file(
+                  ${{CMAKE_CURRENT_SOURCE_DIR}}/cmake/{0}-config.cmake.in
+                  ${{CMAKE_BINARY_DIR}}/{0}-config.cmake
+                  INSTALL_DESTINATION share/cmake/{0}
+                )
+                
+                install(DIRECTORY src/
+                  DESTINATION "${{CMAKE_INSTALL_INCLUDEDIR}}"
+                  FILES_MATCHING PATTERN "*.hpp"
+                  PATTERN "*test*" EXCLUDE
+                )
+                
+                install(FILES
+                  "${{PROJECT_BINARY_DIR}}/{0}-config.cmake"
+                  DESTINATION share/cmake/{0}
+                )
+                
+                if(NOT subproject)
+                  set(CPACK_PACKAGE_VENDOR "Los Alamos National Laboratory")
+                  set(CPACK_RESOURCE_FILE_LICENSE "${{CMAKE_CURRENT_SOURCE_DIR}}/LICENSE")
+                  include(CPack)
+                endif()
+            endif()
+            
             """.format(self.name))
             )
 
@@ -312,9 +407,36 @@ class BuildSystem:
             os.path.join(
                 self._path,
                 'cmake',
-                filename
-                )
+                filename,
+                ),
+                self.name
             )
+    
+    def write_installation_dependencies(self):
+        filename = os.path.join(
+            self._path,
+            'cmake',
+            "{}-config.cmake.in".format(self.name)
+            )
+
+        with open(filename, 'w') as f:
+            f.write("include(CMakeFindDependencyMacro)\n\n")
+
+            for d in self.dependencies:
+                # Don't include catch as an installation dependency
+                if (d.name != "catch-adapter"): 
+                    # Treat spdlog specially since its installed target is namespaced
+                    if (d.name == "spdlog"): 
+                        f.write('if (NOT TARGET spdlog::spdlog)\n')
+                        f.write('    find_dependency(spdlog)\n')
+                        f.write('endif()\n\n')
+                    else:
+                        f.write('if (NOT TARGET {0})\n'.format(d.name))
+                        f.write('    find_dependency({0})\n'.format(d.name))
+                        f.write('endif()\n\n')
+
+            f.write("""include("${{CMAKE_CURRENT_LIST_DIR}}/{}-targets.cmake")""".format(self.name))
+
 
 
     ###################################################################
@@ -394,7 +516,7 @@ class BuildSystem:
                 target_link_libraries( {0}.test
                     PUBLIC {1}
                     )
-                """.format(testname, self.name))
+                """.format(testname, self.testName))
                 )
     
             # compile options

--- a/devtools/dependencies/dependencies.py
+++ b/devtools/dependencies/dependencies.py
@@ -58,7 +58,7 @@ class Dependencies:
                     'Cannot register an object other than a Dependency.')
             self._dependencies.append(dep)
 
-    def cmake_file(self, filename):
+    def cmake_file(self, filename, libName):
         """ Write the dependency information to a CMake file.
 
         """
@@ -95,8 +95,15 @@ class Dependencies:
             """)
             )
         for dependency in self.dependencies:
-            f.write('    {}\n'.format(dependency.name))
-        f.write('    )\n')
+            if (dependency.name != "catch-adapter"):
+                f.write('    {}\n'.format(dependency.name))
+        f.write('    )\n\n')
+
+        # Only look for testing library if testing is enabled
+        if (any(dependency.name == "catch-adapter" for dependency in self.dependencies)):
+            f.write('if (${{{0}_unit_tests}})\n'.format(libName))
+            f.write('    FetchContent_MakeAvailable(catch-adapter)\n')
+            f.write('endif()\n\n')
 
         f.close()
 
@@ -106,4 +113,4 @@ if __name__ == '__main__':
 
     d = Dependencies()
     d.add_dependencies(d1, d2)
-    d.cmake_file('blah.cmake')      
+    d.cmake_file('blah.cmake', 'libraryName')      

--- a/devtools/dependencies/dependency.py
+++ b/devtools/dependencies/dependency.py
@@ -138,7 +138,7 @@ class Dependency:
         """
 
         result = dedent("""\
-            shacl_FetchContent_Declare( {name}
+            FetchContent_Declare( {name}
                 GIT_REPOSITORY  {remote}
                 GIT_TAG         {tag}
             """).format(

--- a/devtools/dependencies/dependency.py
+++ b/devtools/dependencies/dependency.py
@@ -138,7 +138,7 @@ class Dependency:
         """
 
         result = dedent("""\
-            FetchContent_Declare( {name}
+            shacl_FetchContent_Declare( {name}
                 GIT_REPOSITORY  {remote}
                 GIT_TAG         {tag}
             """).format(

--- a/update_repository.py
+++ b/update_repository.py
@@ -113,6 +113,7 @@ def make_build_system(args):
             b.dependencies = deps
 
     b.write_dependencies()
+    b.write_installation_dependencies()
     if not args.release:
         b.write_cmakelists()
         b.write_test_list()


### PR DESCRIPTION
* Adds basic installation logic - needs more complicated logic for installs with executables/libraries most likely
* Adds logic to turn off tests when project is included as a subproject or when BUILD_TESTING (default CTest module option) is turned OFF
* Adds interface library libName_testing that links to name and any testing libs (catch-adapter). This enables both installation and testing at the same time as the testing library never needs to be installed
* Prevents installed libs from linking to catch-adapter
* Prevents finding catch-adapter via FetchContent when tests are turned off
* Adds special treatment of spdlog due to namespace issues
* Adds config files assuming all dependencies except catch-adapter are installation dependencies